### PR TITLE
Add support to textAlign attribute when converting to HTML

### DIFF
--- a/lib/tip_tap/html_renderable.rb
+++ b/lib/tip_tap/html_renderable.rb
@@ -54,7 +54,17 @@ module TipTap
     end
 
     def to_html
-      content_tag(html_tag, safe_join(content.map(&:to_html)), class: html_class_name)
+      content_tag(html_tag, safe_join(content.map(&:to_html)), html_attributes)
+    end
+
+    def html_attributes
+      {style: inline_styles, class: html_class_name}.reject { |key, value| value.blank?}
+    end
+
+    def inline_styles
+      styles = []
+      styles << "text-align: #{attrs['textAlign']};" if attrs["textAlign"]
+      styles.join(" ")
     end
   end
 end

--- a/spec/tip_tap/nodes/heading_spec.rb
+++ b/spec/tip_tap/nodes/heading_spec.rb
@@ -11,6 +11,16 @@ RSpec.describe TipTap::Nodes::Heading do
       expect(html).to be_a(String)
       expect(html).to eq("<h2></h2>")
     end
+
+    context "when the textAlign attribute is present" do
+      it "returns a tag with the specified text alignment style" do
+        node = TipTap::Nodes::Heading.from_json({content: [], attrs: {'textAlign' => 'center', level: 2}})
+        html = node.to_html
+
+        expect(html).to be_a(String)
+        expect(html).to eq('<h2 style="text-align: center;"></h2>')
+      end
+    end
   end
 
   describe "level" do

--- a/spec/tip_tap/nodes/paragraph_spec.rb
+++ b/spec/tip_tap/nodes/paragraph_spec.rb
@@ -11,6 +11,16 @@ RSpec.describe TipTap::Nodes::Paragraph do
       expect(html).to be_a(String)
       expect(html).to eq("<p></p>")
     end
+
+    context "when the textAlign attribute is present" do
+      it "returns a p tag with the specified text alignment style" do
+        node = TipTap::Nodes::Paragraph.from_json({content: [], attrs: {'textAlign' => 'center'}})
+        html = node.to_html
+
+        expect(html).to be_a(String)
+        expect(html).to eq('<p style="text-align: center;"></p>')
+      end
+    end
   end
 
   describe "to_h" do


### PR DESCRIPTION
### Description

It adds support for text alignment on HTML renderable nodes.

### Reason/Reference

Currently, the implementation ignores the `textAlign` attribute when converting to HTML.
